### PR TITLE
🐛 fix(server): Replace netris with nestri in supervisord.conf

### DIFF
--- a/.scripts/supervisord.conf
+++ b/.scripts/supervisord.conf
@@ -10,7 +10,7 @@ files = /etc/supervisord.d/*.ini
 
 [program:entrypoint]
 command=/etc/entrypoint.sh
-user=netris
+user=nestri
 logfile=/tmp/entrypoint.log
 pidfile=/tmp/entrypoint.pid
 stopsignal=INT
@@ -20,7 +20,7 @@ redirect_stderr=true
 priority=1
 
 [program:pulseaudio]
-user=netris
+user=nestri
 command=bash -c "until [ -S \"/tmp/.X11-unix/X${DISPLAY/:/}\" ]; do sleep 1; done; sudo /usr/bin/pulseaudio -k >/dev/null 2>&1 || sudo /usr/bin/pulseaudio --system --verbose --log-target=stderr --realtime=true --disallow-exit -L 'module-native-protocol-tcp auth-ip-acl=127.0.0.0/8 port=4713 auth-anonymous=1'"
 environment=DISPLAY=":0"
 logfile=/tmp/pulseaudio.log
@@ -36,7 +36,7 @@ command=bash -c "until [ -S \"/tmp/.X11-unix/X${DISPLAY/:/}\" ]; do sleep 1; don
 logfile=/tmp/warp-input.log
 pidfile=/tmp/warp-input.pid
 stopsignal=INT
-user=netris
+user=nestri
 environment=HOME="/home/%(ENV_USER)s",USER="%(ENV_USER)s",DISPLAY=":0",SESSION_ID="%(ENV_SESSION_ID)s"
 autostart=true
 autorestart=true


### PR DESCRIPTION

## Description

**What issue are you solving (or what feature are you adding) and how are you doing it?**

Supervisord fails to run as user `netris` no longer exists. So we are renaming all occurrences of old username with new username `nestri`