### PR TITLE
🐛 fix(base): Use meson for gpu-screen-recorder

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -253,8 +253,9 @@ RUN apt-get update -y \
     && find . -maxdepth 1 -type f -name "*libnvrtc.so.*" -exec sh -c 'ln -snf $(basename {}) libnvrtc.so' \; \
     && mkdir -p /usr/local/nvidia/lib && mv -f libnvrtc* /usr/local/nvidia/lib \
     && git clone https://repo.dec05eba.com/gpu-screen-recorder && cd gpu-screen-recorder \
-    && chmod +x ./build.sh ./install.sh \
-    && ./install.sh 
+    && meson setup build \
+    && meson configure --prefix=/usr --buildtype=release -Dsystemd=true -Dstrip=true build \
+    && ninja -C build install
 
 # #Try building shadow-cast
 # RUN git clone https://github.com/gmbeard/shadow-cast && cd shadow-cast \


### PR DESCRIPTION
## Description

The `gpu-screen-recorder` project switched to using meson instead of a custom build script (see [commit](https://git.dec05eba.com/gpu-screen-recorder/commit/?id=dfa7dc6659755b7a8385aad5003fd80483dd4ffe))

Rather than using the `install.sh` which is now deprecated, I switched to using meson and ninja to build & install.

My text-editor wanted to format the end of the file as well, but that is hopefully no issue :sweat_smile: