### PR TITLE
🐛 fix(autolabeller): Use `GITHUB_TOKEN` for autolabelling

### DIFF
--- a/.github/workflows/autolabeller.yml
+++ b/.github/workflows/autolabeller.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: amannn/action-semantic-pull-request@cfb60706e18bc85e8aec535e3c577abe8f70378e
         id: lint_pr_title
         env:
-          GITHUB_TOKEN: ${{ secrets.GIT_MASTER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: |-
             build


### PR DESCRIPTION
## Description

**What issue are you solving (or what feature are you adding) and how are you doing it?**
We are using my personal account key to do autolabelling. This used to work when the project was under my personal, but now it breaks whenever some 3rd party tries to open a PR