### PR TITLE
🐛 fix(labeler): Use remote config

### DIFF
--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -80,6 +80,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout your code
         uses: actions/checkout@v4
@@ -87,7 +88,6 @@ jobs:
       - uses: srvaroa/labeler@v1
         with:
           config_path: .github/labeler.yml
-          use_local_config: true #FIXME:
           fail_on_error: true
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description

**What issue are you solving (or what feature are you adding) and how are you doing it?**

PR labeler does not work on PR forks, still... I dunno why