### PR TITLE
🐛 fix(base): Device selection patch for gpu-screen-recorder

### DIFF
--- a/.patches/devicearg.patch
+++ b/.patches/devicearg.patch
@@ -1,0 +1,23 @@
+diff --git a/src/main.cpp b/src/main.cpp
+index 112a6ac..57bd9bf 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -1906,6 +1906,7 @@ int main(int argc, char **argv) {
+         { "-gopm", Arg { {}, true, false } }, // deprecated, used keyint instead
+         { "-keyint", Arg { {}, true, false } },
+         { "-encoder", Arg { {}, true, false } },
++        { "-device", Arg { {}, true, false } },
+     };
+ 
+     for(int i = 1; i < argc; i += 2) {
+@@ -2226,6 +2227,10 @@ int main(int argc, char **argv) {
+         overclock = false;
+     }
+ 
++    const char *dri_device = args["-device"].value();
++    if (dri_device)
++        egl.dri_card_path = dri_device;
++
+     egl.card_path[0] = '\0';
+     if(wayland || egl.gpu_info.vendor != GSR_GPU_VENDOR_NVIDIA) {
+         // TODO: Allow specifying another card, and in other places

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -203,7 +203,7 @@ ENV \
     # Disable VSYNC for NVIDIA GPUs
      __GL_SYNC_TO_VBLANK=0 
 
-COPY .patches /etc/
+COPY .patches /tmp/
 
 #Build and install gpu-screen-recorder
 RUN apt-get update -y \
@@ -259,7 +259,7 @@ RUN apt-get update -y \
     && find . -maxdepth 1 -type f -name "*libnvrtc.so.*" -exec sh -c 'ln -snf $(basename {}) libnvrtc.so' \; \
     && mkdir -p /usr/local/nvidia/lib && mv -f libnvrtc* /usr/local/nvidia/lib \
     && git clone https://repo.dec05eba.com/gpu-screen-recorder && cd gpu-screen-recorder \
-    && git apply /etc/connectcheckskip.patch \
+    && git apply /tmp/connectcheckskip.patch && git apply /tmp/devicearg.patch \
     && meson setup build \
     && meson configure --prefix=/usr --buildtype=release -Dsystemd=true -Dstrip=true build \
     && ninja -C build install


### PR DESCRIPTION
## Description

Adds new `-device` argument for gpu-screen-recorder which allows specifying a GPU to use (by `/dev/dri/cardN` path)

This fixes an issue with multi-gpu systems when device such as `/dev/dri/card1` is passed through but gpu-screen-recorder will still try to access `/dev/dri/card0` for capturing and failing.

Added relevant bits to `gpu_helpers.sh` to find the card path - I assume all modern modesetting drivers will have a `/drm/` path that tells the card number. If not, the script will fall back to gpu-screen-recorder's own method of finding the card.

Edit: Forgot to mention patches are now copied to /tmp/ rather than /etc/