### PR TITLE
🐛 fix: Container parameter passing, option to disable audio for debugging

### DIFF
--- a/Containerfile.cachyos
+++ b/Containerfile.cachyos
@@ -48,9 +48,8 @@ RUN mkdir plugin && \
 #******************************************************************************
 FROM ${BASE_IMAGE} AS runtime
 
-## Overridable Runtime Environment Variables ##
-# Set relay path #
-ENV RELAY_PATH="teststream"
+## Overridable Runtime Parameters ##
+ENV NESTRI_PARAMS=""
 
 ## Graphics ##
 # Grab display packages (mesa, wayland things) #
@@ -110,14 +109,14 @@ RUN usermod -aG input root && usermod -aG input ${USER} && \
 
 ## Copy files from builders ##
 # this is done here at end to not trigger full rebuild on changes to builder
+# nestri
+COPY --from=gst-builder /builder/nestri/target/release/nestri-server /usr/bin/nestri-server
 # gstwayland
 COPY --from=gstwayland-builder /builder/plugin/include/libgstwaylanddisplay /usr/include/
 COPY --from=gstwayland-builder /builder/plugin/lib/*libgstwayland* /usr/lib/
 COPY --from=gstwayland-builder /builder/plugin/lib/gstreamer-1.0/libgstwayland* /usr/lib/gstreamer-1.0/
 COPY --from=gstwayland-builder /builder/plugin/lib/pkgconfig/gstwayland* /usr/lib/pkgconfig/
 COPY --from=gstwayland-builder /builder/plugin/lib/pkgconfig/libgstwayland* /usr/lib/pkgconfig/
-# nestri
-COPY --from=gst-builder /builder/nestri/target/release/nestri-server /usr/bin/nestri-server
 
 ## Startup ##
 # Grab supervisor package #
@@ -168,7 +167,7 @@ priority=30
 
 [program:nestri-server]
 user=nestri
-command=nestri-server --relay-path=${RELAY_PATH}
+command=sh -c 'nestri-server \$NESTRI_PARAMS'
 environment=XDG_RUNTIME_DIR=\"/run/user/${USER_ID}\",HOME=\"${USER_HOME}\"
 logfile=/tmp/nestri-server.log
 autostart=true

--- a/Containerfile.cachyos
+++ b/Containerfile.cachyos
@@ -14,7 +14,7 @@ RUN pacman -Syu --noconfirm meson pkgconf cmake git gcc make rustup \
 # Setup stable rust toolchain #
 RUN rustup default stable
 # Clone nestri source #
-RUN git clone -b feat/stream https://github.com/DatCaptainHorse/nestri.git
+RUN git clone -b feat/stream https://github.com/nestriness/nestri.git
 
 # Build nestri #
 RUN cd nestri/packages/server/ && \

--- a/packages/server/src/args.rs
+++ b/packages/server/src/args.rs
@@ -29,6 +29,8 @@ pub struct Args {
     pub encoder_name: String,
     /// Encoder CQP quality level (e.g. 25)
     pub encoder_cqp: u32,
+    /// Whether to disable audio output
+    pub no_audio: bool,
 }
 
 impl Args {
@@ -148,6 +150,14 @@ impl Args {
                     .help("Encoder CQP quality level, lower values mean higher quality at cost of higher bitrate")
                     .default_value("25"),
             )
+            .arg(
+                Arg::new("no-audio")
+                    .short('x')
+                    .long("no-audio")
+                    .env("NO_AUDIO")
+                    .help("Disable audio output")
+                    .default_value("false"),
+            )
             .get_matches();
 
         Self {
@@ -202,6 +212,8 @@ impl Args {
                 .unwrap()
                 .parse::<u32>()
                 .unwrap(),
+            no_audio: matches.get_one::<String>("no-audio").unwrap() == "true"
+                || matches.get_one::<String>("no-audio").unwrap() == "1",
         }
     }
 
@@ -220,5 +232,7 @@ impl Args {
         println!("> Encoder Video Codec: {}", self.encoder_vcodec);
         println!("> Encoder Type: {}", self.encoder_type);
         println!("> Encoder Name: {}", self.encoder_name);
+        println!("> Encoder CQP: {}", self.encoder_cqp);
+        println!("> No Audio: {}", self.no_audio);
     }
 }

--- a/packages/server/src/main.rs
+++ b/packages/server/src/main.rs
@@ -320,6 +320,13 @@ async fn main() -> std::io::Result<()> {
         debug_sink = "dfee. ! queue2 max-size-time=1000000 ! videoconvert ! ximagesink"
     }
 
+    // Audio sub-pipeline
+    let audio_pipeline = "
+        pipewiresrc \
+        ! queue2 max-size-time=1000000 ! audioconvert \
+        ! faac bitrate=196000 \
+        ! aacparse ! mux.";
+
     // Construct the pipeline string
     let pipeline_str = format!(
         "
@@ -331,7 +338,7 @@ async fn main() -> std::io::Result<()> {
         ! {} \
         ! isofmp4mux chunk-duration=1 fragment-duration=1 name=mux \
         ! moqsink url={} broadcast={} \
-        pipewiresrc ! audioconvert ! faac bitrate=196000 ! aacparse ! mux. \
+        {} \
         {debug_sink}
         ",
         gpu.render_path(),
@@ -345,6 +352,7 @@ async fn main() -> std::io::Result<()> {
             .unwrap_or("h264parse"),
         args.relay_url,
         args.relay_path,
+        args.no_audio.then(|| "").unwrap_or(audio_pipeline),
     );
 
     // If verbose, print out the pipeline string
@@ -404,7 +412,7 @@ async fn main() -> std::io::Result<()> {
             .service(web::resource("/ws").route(web::get().to(handle_events)))
             .service(web::resource("/").route(web::get().to(hello_world)))
     })
-    .bind("0.0.0.0:8081")?
-    .run()
-    .await
+        .bind("0.0.0.0:8081")?
+        .run()
+        .await
 }

--- a/packages/server/src/main.rs
+++ b/packages/server/src/main.rs
@@ -323,7 +323,7 @@ async fn main() -> std::io::Result<()> {
     // Construct the pipeline string
     let pipeline_str = format!(
         "
-        waylanddisplaysrc \
+        waylanddisplaysrc render-node={} \
         ! video/x-raw,width={},height={},framerate={}/1,format=RGBx \
         {debug_feed} \
         ! queue2 max-size-time=1000000 ! videoconvert \
@@ -334,6 +334,7 @@ async fn main() -> std::io::Result<()> {
         pipewiresrc ! audioconvert ! faac bitrate=196000 ! aacparse ! mux. \
         {debug_sink}
         ",
+        gpu.render_path(),
         args.resolution.0,
         args.resolution.1,
         args.framerate,


### PR DESCRIPTION
Adds a functional NESTRI_PARAMS env variable to container image, allowing usage like:
```docker run -e NESTRI_PARAMS='--no-audio=true --verbose=true'```

Also adds a no-audio option to help debug stream issues.
Also also, changes the container builder portion to use the actual main nestri repo.